### PR TITLE
Issue #72: Use PAT on GHA workflow

### DIFF
--- a/.github/workflows/package-updates.yml
+++ b/.github/workflows/package-updates.yml
@@ -25,3 +25,5 @@ jobs:
         run: npm update
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
テスト用のワークフローをトリガーするためにパッケージ更新のワークフローで PAT を使用します。

Close #72 

- #72

See:

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow